### PR TITLE
Unified mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
     - [Filtering by metafields](#filtering-by-metafields)
   - [Fetch](#fetch)
   - [Set up MCP](#set-up-mcp)
+    - [Unified MCP (recommended)](#unified-mcp-recommended)
+    - [Simple MCP](#simple-mcp)
+  - [Run unit tests](#run-unit-tests)
 - [Good to know](#good-to-know)
 
 ## Overview
@@ -240,7 +243,57 @@ uv run collection_fetch_cmd_adapter.py \
 
 ### Set up MCP
 
+There are two MCP server adapters:
+
+| Adapter | Best for | Key differences |
+|---|---|---|
+| `collection_search_unified_mcp_adapter.py` | Modern AI models | All collections in one server. AI model chooses collection, filter and number of chunks. Supports stdio and HTTP transport. |
+| `collection_search_mcp_stdio_adapter.py` | Simpler AI models or restricted setups | One collection per server. Collection, filter and other settings are hardcoded via CLI args. Stdio only. |
+
+#### Unified MCP (recommended)
+
 Add to your MCP config (e.g., `.vscode/mcp.json` for VS Code + GitHub Copilot):
+
+```json
+{
+    "servers": {
+        "dvs": {
+            "type": "stdio",
+            "command": "uv",
+            "args": [
+                "--directory", "${fullPathToRootProjectFolder}",
+                "run", "collection_search_unified_mcp_adapter.py"
+            ]
+        }
+    }
+}
+```
+
+- All collections from `./data/collections/` are available automatically
+- Use `--collections "name1" "name2"` to limit which collections are exposed
+- Use `--rrfK {number}` to tune Reciprocal Rank Fusion behavior for multi-index search
+- Use  `--defaultNumberOfChunks {number}` and `--maxNumberOfChunks {number}` to tune the number of text chunks returned by a single search
+
+Or start as http server:
+
+```bash
+uv run collection_search_unified_mcp_adapter.py --http --port 8000
+```
+
+And setup mcp like:
+
+```json
+{
+    "servers": {
+        "dvs": {
+            "type": "http",
+            "url": "http://localhost:8000/mcp",
+        }
+    }
+}
+```
+
+#### Simple MCP
 
 ```json
 {

--- a/UPDATES.md
+++ b/UPDATES.md
@@ -1,5 +1,8 @@
 # Updates
 
+## 2026/04/22
+- Added unified MCP adapter (`collection_search_unified_mcp_adapter.py`): serves all collections from one MCP server, AI model can choose collection, filter results by metadata and control number of returned chunks. Supports stdio and HTTP transport. The previous simple MCP adapter (`collection_search_mcp_stdio_adapter.py`) is still available for simpler setups.
+
 ## 2026/04/20
 - Fixed https://github.com/shnax0210/documents-vector-search/issues/15
 - Improved Confluence update query to ave only 5 mins of overlap between two updates;

--- a/collection_search_cmd_adapter.py
+++ b/collection_search_cmd_adapter.py
@@ -27,7 +27,7 @@ ap.add_argument("-includeMatchedChunksText", "--includeMatchedChunksText", actio
 ap.add_argument("-format", "--format", default="json_with_indent", required=False, choices=['json', 'json_with_indent', 'toon'], help="Output format for the search result (e.g., 'json', 'json_with_indent', 'toon')")
 args = vars(ap.parse_args())
 
-searcher = create_collection_searcher(collection_name=args['collection'], index_names=args['indexes'], filter=args['filter'], rrf_k=args['rrfK'])
+searcher = create_collection_searcher(collection_name=args['collection'], index_names=args['indexes'], rrf_k=args['rrfK'])
 
 max_number_of_chunks = args['maxNumberOfChunks'] if args['maxNumberOfChunks'] is not None else args['maxNumberOfDocuments'] * 3
 search_result = log_execution_duration(lambda: searcher.search(args['query'],
@@ -35,7 +35,8 @@ search_result = log_execution_duration(lambda: searcher.search(args['query'],
                                                                max_number_of_documents=args['maxNumberOfDocuments'], 
                                                                include_text_content=args['includeFullText'], 
                                                                include_matched_chunks_content=args['includeMatchedChunksText'],
-                                                               include_all_chunks_content=args['includeAllChunksText']),
+                                                               include_all_chunks_content=args['includeAllChunksText'],
+                                                               filter=args['filter']),
                                        identifier=f"Searching collection: \"{args['collection']}\" by query: \"{args['query']}\"")
 
 logging.info(f"Search results:\n{format_object(search_result, args['format'])}")

--- a/collection_search_mcp_stdio_adapter.py
+++ b/collection_search_mcp_stdio_adapter.py
@@ -29,7 +29,7 @@ ap.add_argument("-includeFullText", "--includeFullText", action="store_true", re
 ap.add_argument("-format", "--format", default="toon", required=False, choices=['json', 'json_with_indent', 'toon'], help="Output format for the search result (e.g., 'json', 'json_with_indent', 'toon')")
 args = vars(ap.parse_args())
 
-searcher = create_collection_searcher(collection_name=args['collection'], index_names=args['indexes'], filter=args['filter'], rrf_k=args['rrfK'])
+searcher = create_collection_searcher(collection_name=args['collection'], index_names=args['indexes'], rrf_k=args['rrfK'])
 fetcher = create_collection_fetcher(collection_name=args['collection'])
 
 tool_description = """The tool allows searching in collection of documents by vector search. 
@@ -41,7 +41,8 @@ def search_documents(query: str) -> str:
                                      max_number_of_chunks=args['maxNumberOfChunks'], 
                                      max_number_of_documents=args['maxNumberOfDocuments'],
                                      include_text_content=args['includeFullText'],
-                                     include_matched_chunks_content=not args['includeFullText'])
+                                     include_matched_chunks_content=not args['includeFullText'],
+                                     filter=args['filter'])
 
     return format_object(search_results, args['format'])
 

--- a/collection_search_unified_mcp_adapter.py
+++ b/collection_search_unified_mcp_adapter.py
@@ -14,13 +14,19 @@ from main.factories.search_collection_factory import create_collection_searcher
 from main.utils.formatting import format_object
 from main.utils.logger import setup_root_logger
 
-setup_root_logger(use_stderr=True)
-
 ap = argparse.ArgumentParser()
 ap.add_argument("-c", "--collections", nargs="*", default=None, help="Collections to search in. If not passed, all collections are available.")
 ap.add_argument("-rrfK", "--rrfK", required=False, type=int, default=60, help="RRF constant for multi-index search fusion.")
 ap.add_argument("-f", "--format", default="toon", required=False, choices=["json", "json_with_indent", "toon"], help="Output format.")
+
+ap.add_argument("--http", action="store_true", default=False, help="Run MCP server over HTTP (streamable-http) instead of stdio.")
+ap.add_argument("--http-port", type=int, default=8000, help="Port for HTTP transport (default: 8000).")
+
 args = vars(ap.parse_args())
+
+transport = "streamable-http" if args["http"] else "stdio"
+
+setup_root_logger(use_stderr=(transport == "stdio"))
 
 __COLLECTIONS_BASE_PATH = "./data/collections"
 
@@ -127,7 +133,7 @@ if not discovered:
     print("Error: no collections found.", file=sys.stderr)
     sys.exit(1)
 
-mcp = FastMCP("documents-search-unified")
+mcp = FastMCP("documents-search-unified", port=args["http_port"])
 
 search_description = __build_search_tool_description(discovered)
 available_names = {c["name"] for c in discovered}
@@ -186,4 +192,4 @@ def fetch_from_collection(
     return format_object(result, args["format"])
 
 
-mcp.run(transport="stdio")
+mcp.run(transport=transport)

--- a/collection_search_unified_mcp_adapter.py
+++ b/collection_search_unified_mcp_adapter.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import sys
+import threading
+from typing import Annotated
+
+from mcp.server.fastmcp import FastMCP
+from pydantic import Field
+
+from main.factories.fetch_collection_factory import create_collection_fetcher
+from main.factories.search_collection_factory import create_collection_searcher
+from main.utils.formatting import format_object
+from main.utils.logger import setup_root_logger
+
+setup_root_logger(use_stderr=True)
+
+ap = argparse.ArgumentParser()
+ap.add_argument("-c", "--collections", nargs="*", default=None, help="Collections to search in. If not passed, all collections are available.")
+ap.add_argument("-rrfK", "--rrfK", required=False, type=int, default=60, help="RRF constant for multi-index search fusion.")
+ap.add_argument("-f", "--format", default="toon", required=False, choices=["json", "json_with_indent", "toon"], help="Output format.")
+args = vars(ap.parse_args())
+
+__COLLECTIONS_BASE_PATH = "./data/collections"
+
+__COLLECTION_TYPE_MAP = {
+    "confluence": "confluence",
+    "confluenceCloud": "confluence",
+    "jira": "jira",
+    "jiraCloud": "jira",
+    "localFiles": "files",
+}
+
+__FILTER_FIELDS_BY_TYPE = {
+    "confluence": ["space", "createdAt", "createdBy", "lastModifiedAt"],
+    "jira": ["project", "type", "status", "priority", "epic", "assignee", "createdAt", "createdBy", "lastModifiedAt"],
+    "files": ["createdAt", "lastModifiedAt", "folder1", "folder2", "...", "folderN"],
+}
+
+
+def __discover_collections(allowed_names: list[str] | None) -> list[dict]:
+    collections = []
+    for name in sorted(os.listdir(__COLLECTIONS_BASE_PATH)):
+        manifest_path = os.path.join(__COLLECTIONS_BASE_PATH, name, "manifest.json")
+        if not os.path.isfile(manifest_path):
+            continue
+        with open(manifest_path, "r", encoding="utf-8") as f:
+            manifest = json.load(f)
+        reader_type = manifest.get("reader", {}).get("type", "")
+        collection_type = __COLLECTION_TYPE_MAP.get(reader_type)
+        if not collection_type:
+            continue
+        if allowed_names is not None and name not in allowed_names:
+            continue
+        collections.append({
+            "name": name,
+            "type": collection_type,
+            "numberOfDocuments": manifest.get("numberOfDocuments"),
+        })
+    return collections
+
+
+def __validate_collections(allowed_names: list[str], discovered: list[dict]) -> None:
+    discovered_names = {c["name"] for c in discovered}
+    missing = set(allowed_names) - discovered_names
+    if missing:
+        print(f"Error: collections not found: {', '.join(sorted(missing))}", file=sys.stderr)
+        sys.exit(1)
+
+
+def __build_search_tool_description(collections: list[dict]) -> str:
+    present_types = sorted({c["type"] for c in collections})
+
+    filter_rows = "\n".join(
+        f"| {t} | {', '.join(__FILTER_FIELDS_BY_TYPE[t])} |"
+        for t in present_types
+    )
+
+    collection_rows = "\n".join(
+        f"| {c['name']} | {c['type']} | {c['numberOfDocuments']} |"
+        for c in collections
+    )
+
+    return f"""Search in a collection of documents by vector search.
+Each document contains 'url' field, if you consider a document as relevant to the query, always include the 'url' field in the response, put it close to the information used from the document.
+
+Available collections:
+
+| Collection name | Collection type | Number of documents |
+|---|---|---|
+{collection_rows}
+
+Filter fields by collection type:
+
+| Collection type | Filter fields |
+|---|---|
+{filter_rows}
+
+Filter syntax: `field operator "value"`. Operators: =, !=, >, >=, <, <=. Combine conditions with `and` / `or`. Use parentheses for grouping.
+Examples:
+- space = "SPACE_KEY"
+- space = "SPACE_KEY" and lastModifiedAt > "2026-01-01"
+- (space = "X" or space = "Y") and createdBy = "user"
+"""
+
+
+__FETCH_TOOL_DESCRIPTION = """Fetch a full document from a collection by its id.
+Use startLine and endLine to read a specific portion of the document. If document is too large, fetch it in parts.
+
+`id` means:
+- For Confluence: page id.
+- For Jira: issue key (e.g. PROJ-123).
+- For files collection: relative path.
+
+Users often provides url to the document, extract id from the url and use it to fetch the document in the case.
+
+Available collections are listed in the description of search tool.
+"""
+
+discovered = __discover_collections(args["collections"])
+
+if args["collections"] is not None:
+    __validate_collections(args["collections"], discovered)
+
+if not discovered:
+    print("Error: no collections found.", file=sys.stderr)
+    sys.exit(1)
+
+mcp = FastMCP("documents-search-unified")
+
+search_description = __build_search_tool_description(discovered)
+available_names = {c["name"] for c in discovered}
+
+searcher_cache = {}
+searcher_cache_lock = threading.Lock()
+
+
+def __get_or_create_searcher(collectionName: str):
+    if collectionName in searcher_cache:
+        return searcher_cache[collectionName]
+
+    with searcher_cache_lock:
+        if collectionName not in searcher_cache:
+            searcher_cache[collectionName] = create_collection_searcher(
+                collection_name=collectionName,
+                rrf_k=args["rrfK"],
+            )
+
+    return searcher_cache[collectionName]
+
+
+@mcp.tool(name="search_in_collection", description=search_description)
+def search_in_collection(
+    collectionName: Annotated[str, Field(description="Collection name must be one of the available collections listed above.")],
+    query: Annotated[str, Field(description="Search query text for vector similarity and keyword search.", default="")],
+    filter: Annotated[str | None, Field(description="Filter expression to narrow results. See filter syntax above.", default=None)],
+    maxNumberOfChunks: Annotated[int, Field(description="Maximum number of document chunks to return. Prefer to use default value unless there is strong reason to change", default=50)],
+) -> str:
+    if collectionName not in available_names:
+        return f"Error: collection '{collectionName}' is not available. Available: {', '.join(sorted(available_names))}"
+    if not query and not filter:
+        return "Error: at least one of 'query' or 'filter' must be provided."
+
+    search_results = __get_or_create_searcher(collectionName).search(
+        query or "",
+        max_number_of_chunks=maxNumberOfChunks,
+        include_matched_chunks_content=True,
+        filter=filter or None,
+    )
+    return format_object(search_results, args["format"])
+
+
+@mcp.tool(name="fetch_from_collection", description=__FETCH_TOOL_DESCRIPTION)
+def fetch_from_collection(
+    collectionName: Annotated[str, Field(description="Name of the collection to fetch from. Must be one of the available collections.")],
+    id: Annotated[str, Field(description="Document identifier. Confluence: page id. Jira: issue key (e.g. PROJ-123). Files: relative path.")],
+    startLine: Annotated[int, Field(description="First line number to return (1-based, inclusive). Default: 1.", default=1)],
+    endLine: Annotated[int, Field(description="Last line number to return (1-based, inclusive). Default: 250.", default=250)],
+) -> str:
+    if collectionName not in available_names:
+        return f"Error: collection '{collectionName}' is not available. Available: {', '.join(sorted(available_names))}"
+
+    fetcher = create_collection_fetcher(collection_name=collectionName)
+    result = fetcher.fetch(id=id, start_line=startLine, end_line=endLine)
+    return format_object(result, args["format"])
+
+
+mcp.run(transport="stdio")

--- a/collection_search_unified_mcp_adapter.py
+++ b/collection_search_unified_mcp_adapter.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import logging
 import os
-import sys
 import threading
 from typing import Annotated
 
@@ -18,6 +18,9 @@ ap = argparse.ArgumentParser()
 ap.add_argument("-c", "--collections", nargs="*", default=None, help="Collections to search in. If not passed, all collections are available.")
 ap.add_argument("-rrfK", "--rrfK", required=False, type=int, default=60, help="RRF constant for multi-index search fusion.")
 ap.add_argument("-f", "--format", default="toon", required=False, choices=["json", "json_with_indent", "toon"], help="Output format.")
+
+ap.add_argument("--defaultNumberOfChunks", type=int, default=50, help="Default number of chunks returned by search (default: 50).")
+ap.add_argument("--maxNumberOfChunks", type=int, default=100, help="Maximum allowed number of chunks for search (default: 100).")
 
 ap.add_argument("--http", action="store_true", default=False, help="Run MCP server over HTTP (streamable-http) instead of stdio.")
 ap.add_argument("--http-port", type=int, default=8000, help="Port for HTTP transport (default: 8000).")
@@ -43,18 +46,27 @@ FILTER_FIELDS_BY_TYPE = {
     "files": ["createdAt", "lastModifiedAt", "folder1", "folder2", "...", "folderN"],
 }
 
+def __read_json_file(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
 def __discover_collections(allowed_names: list[str] | None) -> list[dict]:
     collections = []
     for name in sorted(os.listdir(COLLECTIONS_BASE_PATH)):
-        manifest_path = os.path.join(COLLECTIONS_BASE_PATH, name, "manifest.json")
+        collection_path = os.path.join(COLLECTIONS_BASE_PATH, name)
+        manifest_path = os.path.join(collection_path, "manifest.json")
+
         if not os.path.isfile(manifest_path):
             continue
-        with open(manifest_path, "r", encoding="utf-8") as f:
-            manifest = json.load(f)
+
+        manifest = __read_json_file(manifest_path)
+
         reader_type = manifest.get("reader", {}).get("type", "")
         collection_type = COLLECTION_TYPE_MAP.get(reader_type)
+
         if not collection_type:
-            continue
+            raise ValueError(f"Unknown reader type '{reader_type}' for collection '{name}' in manifest.json. Supported types: {COLLECTION_TYPE_MAP}")
+
         if allowed_names is not None and name not in allowed_names:
             continue
         collections.append({
@@ -68,8 +80,7 @@ def __validate_collections(allowed_names: list[str], discovered: list[dict]) -> 
     discovered_names = {c["name"] for c in discovered}
     missing = set(allowed_names) - discovered_names
     if missing:
-        print(f"Error: collections not found: {', '.join(sorted(missing))}", file=sys.stderr)
-        sys.exit(1)
+        raise ValueError(f"Error: collections not found: {', '.join(sorted(missing))}, available: {', '.join(sorted(discovered_names))}")
 
 def __build_search_tool_description(collections: list[dict]) -> str:
     present_types = sorted({c["type"] for c in collections})
@@ -125,8 +136,7 @@ if args["collections"] is not None:
     __validate_collections(args["collections"], discovered)
 
 if not discovered:
-    print("Error: no collections found.", file=sys.stderr)
-    sys.exit(1)
+    raise ValueError("Error: no collections found.")
 
 search_description = __build_search_tool_description(discovered)
 available_names = {c["name"] for c in discovered}
@@ -154,16 +164,18 @@ def search_in_collection(
     collectionName: Annotated[str, Field(description="Collection name must be one of the available collections listed above.")],
     query: Annotated[str, Field(description="Search query text for vector similarity and keyword search.", default="")],
     filter: Annotated[str | None, Field(description="Filter expression to narrow results. See filter syntax above.", default=None)],
-    maxNumberOfChunks: Annotated[int, Field(description="Maximum number of document chunks to return. Prefer to use default value unless there is strong reason to change", default=50)],
+    numberOfChunks: Annotated[int, Field(description=f"Number of best matched document chunks to return. Prefer to use default value unless there is strong reason to change. Max allowed: {args['maxNumberOfChunks']}.", default=args["defaultNumberOfChunks"])],
 ) -> str:
     if collectionName not in available_names:
         return f"Error: collection '{collectionName}' is not available. Available: {', '.join(sorted(available_names))}"
     if not query and not filter:
         return "Error: at least one of 'query' or 'filter' must be provided."
+    if numberOfChunks > args["maxNumberOfChunks"]:
+        return f"Error: numberOfChunks ({numberOfChunks}) exceeds maximum allowed ({args['maxNumberOfChunks']})."
 
     search_results = __get_or_create_searcher(collectionName).search(
         query or "",
-        max_number_of_chunks=maxNumberOfChunks,
+        max_number_of_chunks=numberOfChunks,
         include_matched_chunks_content=True,
         filter=filter or None,
     )

--- a/collection_search_unified_mcp_adapter.py
+++ b/collection_search_unified_mcp_adapter.py
@@ -21,16 +21,15 @@ ap.add_argument("-f", "--format", default="toon", required=False, choices=["json
 
 ap.add_argument("--http", action="store_true", default=False, help="Run MCP server over HTTP (streamable-http) instead of stdio.")
 ap.add_argument("--http-port", type=int, default=8000, help="Port for HTTP transport (default: 8000).")
-
 args = vars(ap.parse_args())
 
 transport = "streamable-http" if args["http"] else "stdio"
 
 setup_root_logger(use_stderr=(transport == "stdio"))
 
-__COLLECTIONS_BASE_PATH = "./data/collections"
+COLLECTIONS_BASE_PATH = "./data/collections"
 
-__COLLECTION_TYPE_MAP = {
+COLLECTION_TYPE_MAP = {
     "confluence": "confluence",
     "confluenceCloud": "confluence",
     "jira": "jira",
@@ -38,23 +37,22 @@ __COLLECTION_TYPE_MAP = {
     "localFiles": "files",
 }
 
-__FILTER_FIELDS_BY_TYPE = {
+FILTER_FIELDS_BY_TYPE = {
     "confluence": ["space", "createdAt", "createdBy", "lastModifiedAt"],
     "jira": ["project", "type", "status", "priority", "epic", "assignee", "createdAt", "createdBy", "lastModifiedAt"],
     "files": ["createdAt", "lastModifiedAt", "folder1", "folder2", "...", "folderN"],
 }
 
-
 def __discover_collections(allowed_names: list[str] | None) -> list[dict]:
     collections = []
-    for name in sorted(os.listdir(__COLLECTIONS_BASE_PATH)):
-        manifest_path = os.path.join(__COLLECTIONS_BASE_PATH, name, "manifest.json")
+    for name in sorted(os.listdir(COLLECTIONS_BASE_PATH)):
+        manifest_path = os.path.join(COLLECTIONS_BASE_PATH, name, "manifest.json")
         if not os.path.isfile(manifest_path):
             continue
         with open(manifest_path, "r", encoding="utf-8") as f:
             manifest = json.load(f)
         reader_type = manifest.get("reader", {}).get("type", "")
-        collection_type = __COLLECTION_TYPE_MAP.get(reader_type)
+        collection_type = COLLECTION_TYPE_MAP.get(reader_type)
         if not collection_type:
             continue
         if allowed_names is not None and name not in allowed_names:
@@ -66,7 +64,6 @@ def __discover_collections(allowed_names: list[str] | None) -> list[dict]:
         })
     return collections
 
-
 def __validate_collections(allowed_names: list[str], discovered: list[dict]) -> None:
     discovered_names = {c["name"] for c in discovered}
     missing = set(allowed_names) - discovered_names
@@ -74,12 +71,11 @@ def __validate_collections(allowed_names: list[str], discovered: list[dict]) -> 
         print(f"Error: collections not found: {', '.join(sorted(missing))}", file=sys.stderr)
         sys.exit(1)
 
-
 def __build_search_tool_description(collections: list[dict]) -> str:
     present_types = sorted({c["type"] for c in collections})
 
     filter_rows = "\n".join(
-        f"| {t} | {', '.join(__FILTER_FIELDS_BY_TYPE[t])} |"
+        f"| {t} | {', '.join(FILTER_FIELDS_BY_TYPE[t])} |"
         for t in present_types
     )
 
@@ -110,8 +106,7 @@ Examples:
 - (space = "X" or space = "Y") and createdBy = "user"
 """
 
-
-__FETCH_TOOL_DESCRIPTION = """Fetch a full document from a collection by its id.
+FETCH_TOOL_DESCRIPTION = """Fetch a full document from a collection by its id.
 Use startLine and endLine to read a specific portion of the document. If document is too large, fetch it in parts.
 
 `id` means:
@@ -133,14 +128,11 @@ if not discovered:
     print("Error: no collections found.", file=sys.stderr)
     sys.exit(1)
 
-mcp = FastMCP("documents-search-unified", port=args["http_port"])
-
 search_description = __build_search_tool_description(discovered)
 available_names = {c["name"] for c in discovered}
 
 searcher_cache = {}
 searcher_cache_lock = threading.Lock()
-
 
 def __get_or_create_searcher(collectionName: str):
     if collectionName in searcher_cache:
@@ -155,6 +147,7 @@ def __get_or_create_searcher(collectionName: str):
 
     return searcher_cache[collectionName]
 
+mcp = FastMCP("documents-search-unified", port=args["http_port"])
 
 @mcp.tool(name="search_in_collection", description=search_description)
 def search_in_collection(
@@ -176,8 +169,7 @@ def search_in_collection(
     )
     return format_object(search_results, args["format"])
 
-
-@mcp.tool(name="fetch_from_collection", description=__FETCH_TOOL_DESCRIPTION)
+@mcp.tool(name="fetch_from_collection", description=FETCH_TOOL_DESCRIPTION)
 def fetch_from_collection(
     collectionName: Annotated[str, Field(description="Name of the collection to fetch from. Must be one of the available collections.")],
     id: Annotated[str, Field(description="Document identifier. Confluence: page id. Jira: issue key (e.g. PROJ-123). Files: relative path.")],
@@ -190,6 +182,5 @@ def fetch_from_collection(
     fetcher = create_collection_fetcher(collection_name=collectionName)
     result = fetcher.fetch(id=id, start_line=startLine, end_line=endLine)
     return format_object(result, args["format"])
-
 
 mcp.run(transport=transport)

--- a/main/core/documents_collection_searcher.py
+++ b/main/core/documents_collection_searcher.py
@@ -6,19 +6,14 @@ from ..indexes.indexers.base_indexer import BaseIndexer
 from ..persisters.base_persister import BasePersister
 
 class DocumentCollectionSearcher:
-    def __init__(self, collection_name: str, indexers: List[BaseIndexer], persister: BasePersister, filter: Optional[str] = None, rrf_k: int = 60):
+    def __init__(self, collection_name: str, indexers: List[BaseIndexer], persister: BasePersister, rrf_k: int = 60):
         if rrf_k <= 0:
             raise ValueError("rrf_k should be greater than 0")
 
         self.collection_name = collection_name
         self.__indexers = indexers
         self.__persister = persister
-        self.__filter = filter
         self.__rrf_k = rrf_k
-
-        for indexer in self.__indexers:
-            if self.__filter and not indexer.support_metadata():
-                raise NotImplementedError(f"Filter works only with indexers that support metadata (chromadb), {indexer.get_name()} does not support it.")
 
     def search(self, 
                text, 
@@ -26,11 +21,17 @@ class DocumentCollectionSearcher:
                max_number_of_documents=None, 
                include_text_content=False, 
                include_all_chunks_content=False, 
-               include_matched_chunks_content=False) -> dict:
+               include_matched_chunks_content=False,
+               filter: Optional[str] = None) -> dict:
+        if filter:
+            for indexer in self.__indexers:
+                if not indexer.support_metadata():
+                    raise NotImplementedError(f"Filter works only with indexers that support metadata (chromadb), {indexer.get_name()} does not support it.")
+
         if len(self.__indexers) == 1:
-            scores, indexes = self.__indexers[0].search(text, max_number_of_chunks, self.__filter)
+            scores, indexes = self.__indexers[0].search(text, max_number_of_chunks, filter)
         else:
-            scores, indexes = self.__multi_index_search(text, max_number_of_chunks)
+            scores, indexes = self.__multi_index_search(text, max_number_of_chunks, filter)
 
         results = self.__build_results(scores, indexes, include_text_content, include_all_chunks_content, include_matched_chunks_content)
         if max_number_of_documents:
@@ -42,11 +43,11 @@ class DocumentCollectionSearcher:
             "results": results,
         }
 
-    def __multi_index_search(self, text, max_number_of_chunks):
+    def __multi_index_search(self, text, max_number_of_chunks, filter):
         rrf_scores = {}
 
         for indexer in self.__indexers:
-            scores, indexes = indexer.search(text, max_number_of_chunks, self.__filter)
+            scores, indexes = indexer.search(text, max_number_of_chunks, filter)
             if len(indexes[0]) == 0:
                 continue
             for rank, chunk_id in enumerate(indexes[0]):

--- a/main/factories/search_collection_factory.py
+++ b/main/factories/search_collection_factory.py
@@ -4,13 +4,13 @@ from main.core.documents_collection_searcher import DocumentCollectionSearcher
 
 from main.utils.performance import log_execution_duration
 
-def create_collection_searcher(collection_name, index_names, filter=None, rrf_k=60) -> DocumentCollectionSearcher:
+def create_collection_searcher(collection_name, index_names=None, rrf_k=60) -> DocumentCollectionSearcher:
     return log_execution_duration(
-        lambda: __create_collection_searcher(collection_name, index_names, filter, rrf_k),
+        lambda: __create_collection_searcher(collection_name, index_names, rrf_k),
         identifier=f"Preparing collection searcher"
     )
 
-def __create_collection_searcher(collection_name, index_names, filter, rrf_k):
+def __create_collection_searcher(collection_name, index_names, rrf_k):
     disk_persister = DiskPersister(base_path="./data/collections")
 
     indexers = load_indexers(index_names, collection_name, disk_persister)
@@ -18,5 +18,4 @@ def __create_collection_searcher(collection_name, index_names, filter, rrf_k):
     return DocumentCollectionSearcher(collection_name=collection_name, 
                                       indexers=indexers, 
                                       persister=disk_persister,
-                                      filter=filter,
                                       rrf_k=rrf_k)

--- a/main/indexes/indexer_factory.py
+++ b/main/indexes/indexer_factory.py
@@ -1,12 +1,16 @@
 import json
 import os
-from typing import List, Optional
+import threading
+from typing import List
 from .indexers.base_indexer import BaseIndexer
 from .indexers.faiss_indexer import FaissIndexer
 from .indexers.chroma_indexer import ChromaIndexer
 from .indexers.sqllite_indexer import SqlliteIndexer
 from .embeddings.base_embedder import BaseEmbedder
 from .embeddings.sentence_embeder import SentenceEmbedder
+
+__embedder_cache: dict[str, BaseEmbedder] = {}
+__embedder_cache_lock = threading.Lock()
 
 def __get_available_indexes(collection_name, persister):
     manifest_path = f"{collection_name}/manifest.json"
@@ -31,12 +35,20 @@ def __split_indexer_name(indexer_name):
     raise ValueError(f"Invalid indexer name format: {indexer_name}")
 
 def __create_sentence_embedder(embedding_model) -> BaseEmbedder:
-    # Check for old name formats for backward compatibility
+    if embedding_model in __embedder_cache:
+        return __embedder_cache[embedding_model]
+
+    with __embedder_cache_lock:
+        if embedding_model not in __embedder_cache:
+            __embedder_cache[embedding_model] = __create_sentence_embedder_uncached(embedding_model)
+
+    return __embedder_cache[embedding_model]
+
+def __create_sentence_embedder_uncached(embedding_model) -> BaseEmbedder:
     model = __create_sentence_embedder_by_old_embedding_model_name(embedding_model)
     if model is not None:
         return model
 
-    # New format allows any model name, but it should start with "embeddings_" and replace "/" with "_slash_"
     parsed_model_name = embedding_model.replace("embeddings_", "").replace("_slash_", "/")
     return SentenceEmbedder(model_name=parsed_model_name)
 


### PR DESCRIPTION
Added unified MCP adapter (`collection_search_unified_mcp_adapter.py`): serves all collections from one MCP server, AI model can choose collection, filter results by metadata and control number of returned chunks. Supports stdio and HTTP transport. The previous simple MCP adapter (`collection_search_mcp_stdio_adapter.py`) is still available for simpler setups.