### PR TITLE
Add MCP-ready agent knowledge indexing

### DIFF
--- a/agent_knowledge_collection_create_cmd_adapter.py
+++ b/agent_knowledge_collection_create_cmd_adapter.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import argparse
+
+from main.factories.create_collection_factory import create_collection_creator
+from main.sources.agent_knowledge.agent_knowledge_document_converter import AgentKnowledgeDocumentConverter
+from main.sources.agent_knowledge.agent_knowledge_document_reader import AgentKnowledgeDocumentReader
+from main.splitter.text_splitter import TextSplitter
+from main.utils.logger import setup_root_logger
+
+setup_root_logger()
+
+ap = argparse.ArgumentParser()
+ap.add_argument('-collection', '--collection', required=False, default='agent-knowledge', help='Collection name for indexed agent memories and skills.')
+ap.add_argument('-projectRoot', '--projectRoot', required=True, help='Project root used to discover .deepagents and .agents folders.')
+ap.add_argument('-agentName', '--agentName', required=False, default='agent', help='Agent name used for ~/.deepagents/{agentName}.')
+ap.add_argument('-includeUserKnowledge', '--includeUserKnowledge', action=argparse.BooleanOptionalAction, required=False, default=True, help='Include user-level ~/.deepagents/{agentName} and ~/.agents knowledge.')
+ap.add_argument('-includeProjectKnowledge', '--includeProjectKnowledge', action=argparse.BooleanOptionalAction, required=False, default=True, help='Include project-level .deepagents and .agents knowledge.')
+ap.add_argument('-indexers', '--indexers', required=False, default=['indexer_ChromaDb__embeddings_sentence-transformers_slash_all-MiniLM-L6-v2', 'indexer_SqlLiteBM25'], help='List of indexer names', nargs='+')
+ap.add_argument('-failFast', '--failFast', action='store_true', required=False, default=False, help='Stop on first unreadable agent knowledge file.')
+ap.add_argument('-chunkSize', '--chunkSize', required=False, default=1000, type=int, help='Chunk size for text splitting (default: 1000)')
+ap.add_argument('-chunkOverlap', '--chunkOverlap', required=False, default=100, type=int, help='Chunk overlap for text splitting (default: 100)')
+args = vars(ap.parse_args())
+
+text_splitter = TextSplitter(chunk_size=args['chunkSize'], chunk_overlap=args['chunkOverlap'])
+reader = AgentKnowledgeDocumentReader(
+    project_root=args['projectRoot'],
+    agent_name=args['agentName'],
+    include_user_knowledge=args['includeUserKnowledge'],
+    include_project_knowledge=args['includeProjectKnowledge'],
+    fail_fast=args['failFast'],
+)
+converter = AgentKnowledgeDocumentConverter(text_splitter)
+creator = create_collection_creator(
+    collection_name=args['collection'],
+    indexers=args['indexers'],
+    document_reader=reader,
+    document_converter=converter,
+    use_cache=False,
+)
+creator.run()

--- a/collection_search_unified_mcp_adapter.py
+++ b/collection_search_unified_mcp_adapter.py
@@ -37,12 +37,14 @@ COLLECTION_TYPE_MAP = {
     "jira": "jira",
     "jiraCloud": "jira",
     "localFiles": "files",
+    "agentKnowledge": "agentKnowledge",
 }
 
 FILTER_FIELDS_BY_TYPE = {
     "confluence": ["space", "createdAt", "createdBy", "lastModifiedAt"],
     "jira": ["project", "type", "status", "priority", "epic", "assignee", "createdAt", "createdBy", "lastModifiedAt"],
     "files": ["createdAt", "lastModifiedAt", "folder1", "folder2", "...", "folderN"],
+    "agentKnowledge": ["knowledgeType", "scope", "agentName", "skillName", "lastModifiedAt"],
 }
 
 def __read_json_file(path):
@@ -152,6 +154,56 @@ Examples:
 - (space = "X" or space = "Y") and createdBy = "user"
 """
 
+
+AGENT_SKILLS_TOOL_DESCRIPTION = """Discover reusable agent skills from an agentKnowledge collection.
+Use this when the user asks for capabilities, workflows, reusable procedures, or when a task may match an indexed SKILL.md.
+Returns compact discovery metadata; fetch the returned id with fetch_from_collection to activate the full skill instructions.
+"""
+
+AGENT_MEMORY_TOOL_DESCRIPTION = """Search indexed agent memories and project knowledge from an agentKnowledge collection.
+Use this when project conventions, AGENTS.md guidance, remembered preferences, or past agent knowledge may help answer or perform a task.
+"""
+
+def __combine_filters(required_filter: str, optional_filter: str | None) -> str:
+    if not optional_filter:
+        return required_filter
+    return f"({required_filter}) and ({optional_filter})"
+
+def __agent_knowledge_collections() -> set[str]:
+    return {c['name'] for c in discovered if c['type'] == 'agentKnowledge'}
+
+def __ensure_agent_knowledge_collection(collection: str) -> str | None:
+    if collection not in available_names:
+        return f"Error: collection '{collection}' is not available. Available: {', '.join(sorted(available_names))}"
+    agent_collections = __agent_knowledge_collections()
+    if collection not in agent_collections:
+        return f"Error: collection '{collection}' is not an agentKnowledge collection. Available agentKnowledge collections: {', '.join(sorted(agent_collections)) or 'none'}"
+    return None
+
+def __build_skill_discovery_results(search_results: dict) -> dict:
+    skills = []
+    seen_ids = set()
+    for result in search_results['results']:
+        if result['id'] in seen_ids:
+            continue
+        seen_ids.add(result['id'])
+        first_chunk = result.get('matchedChunks', [{}])[0]
+        metadata = result.get('metadata', {})
+        skills.append({
+            'id': result['id'],
+            'name': metadata.get('skillName'),
+            'description': metadata.get('skillDescription'),
+            'scope': metadata.get('scope'),
+            'agentName': metadata.get('agentName'),
+            'path': metadata.get('sourcePath'),
+            'url': result.get('url'),
+            'score': first_chunk.get('score'),
+        })
+    return {
+        'collection': search_results['collection'],
+        'skills': skills,
+    }
+
 FETCH_TOOL_DESCRIPTION = """Fetch a document content from a collection by its id.
 
 # Typical use cases
@@ -225,5 +277,51 @@ def fetch_from_collection(
     fetcher = create_collection_fetcher(collection_name=collection)
     result = fetcher.fetch(id=id, start_line=startLine, end_line=endLine)
     return format_object(result, args["format"])
+
+
+@mcp.tool(name="discover_agent_skills", description=AGENT_SKILLS_TOOL_DESCRIPTION)
+def discover_agent_skills(
+    collection: Annotated[str, Field(description=collection_field_description)],
+    query: Annotated[str, Field(description="Task or capability description used to find relevant skills.", default="")],
+    numberOfSkills: Annotated[int, Field(description=f"Number of matching skills to return. Max allowed: {args['maxNumberOfChunks']}.", default=10)],
+) -> str:
+    error = __ensure_agent_knowledge_collection(collection)
+    if error:
+        return error
+    if numberOfSkills > args["maxNumberOfChunks"]:
+        return f"Error: numberOfSkills ({numberOfSkills}) exceeds maximum allowed ({args['maxNumberOfChunks']})."
+
+    search_results = __get_or_create_searcher(collection).search(
+        query or "skill",
+        max_number_of_chunks=numberOfSkills * 3,
+        max_number_of_documents=numberOfSkills,
+        include_matched_chunks_content=False,
+        filter='knowledgeType = "skill"',
+    )
+    return format_object(__build_skill_discovery_results(search_results), args["format"])
+
+@mcp.tool(name="search_agent_memory", description=AGENT_MEMORY_TOOL_DESCRIPTION)
+def search_agent_memory(
+    collection: Annotated[str, Field(description=collection_field_description)],
+    query: Annotated[str, Field(description="Search query for AGENTS.md, memory files, and other indexed agent knowledge.", default="")],
+    filter: Annotated[str | None, Field(description=filter_field_description, default=None)],
+    numberOfChunks: Annotated[int, Field(description=f"Number of best matched memory chunks to return. Max allowed: {args['maxNumberOfChunks']}.", default=20)],
+) -> str:
+    error = __ensure_agent_knowledge_collection(collection)
+    if error:
+        return error
+    if not query and not filter:
+        return "Error: at least one of 'query' or 'filter' must be provided."
+    if numberOfChunks > args["maxNumberOfChunks"]:
+        return f"Error: numberOfChunks ({numberOfChunks}) exceeds maximum allowed ({args['maxNumberOfChunks']})."
+
+    search_results = __get_or_create_searcher(collection).search(
+        query or "memory",
+        max_number_of_chunks=numberOfChunks,
+        include_matched_chunks_content=True,
+        filter=__combine_filters('knowledgeType = "memory"', filter),
+    )
+    return format_object(search_results, args["format"])
+
 
 mcp.run(transport=transport)

--- a/main/core/documents_collection_searcher.py
+++ b/main/core/documents_collection_searcher.py
@@ -82,6 +82,7 @@ class DocumentCollectionSearcher:
                     "id": mapping["documentId"],
                     "url": mapping["documentUrl"],
                     "path": mapping["documentPath"],
+                    "metadata": document.get("metadata", {}),
                     "lastModifiedAt":  document["metadata"]["lastModifiedAt"] if "metadata" in document else document.get("modifiedTime"),
                     "matchedChunks": [self.__build_chunk_result(mapping, scores, result_number, include_matched_chunks_content)]
                 }

--- a/main/factories/update_collection_factory.py
+++ b/main/factories/update_collection_factory.py
@@ -13,6 +13,8 @@ from main.sources.confluence.confluence_document_converter import ConfluenceDocu
 from main.sources.confluence.confluence_cloud_document_converter import ConfluenceCloudDocumentConverter
 from main.sources.files.files_document_reader import FilesDocumentReader
 from main.sources.files.files_document_converter import FilesDocumentConverter
+from main.sources.agent_knowledge.agent_knowledge_document_reader import AgentKnowledgeDocumentReader
+from main.sources.agent_knowledge.agent_knowledge_document_converter import AgentKnowledgeDocumentConverter
 from main.indexes.indexer_factory import load_indexer
 from main.core.documents_collection_creator import DocumentCollectionCreator, OPERATION_TYPE
 from main.splitter.text_splitter import TextSplitter
@@ -81,6 +83,10 @@ def __create_reader_and_converter(manifest):
     
     if manifest['reader']['type'] == 'localFiles':
         reader, converter = __create_local_files_reader_and_converter(manifest)
+        return [reader, converter]
+
+    if manifest['reader']['type'] == 'agentKnowledge':
+        reader, converter = __create_agent_knowledge_reader_and_converter(manifest)
         return [reader, converter]
 
     raise Exception(f"Unknown document reader type: {manifest['reader']['type']}")
@@ -183,4 +189,17 @@ def __create_local_files_reader_and_converter(manifest):
                                 fail_fast=fail_fast,
                                 start_from_time=update_time)
     converter = FilesDocumentConverter(__create_text_splitter(manifest))
+    return reader, converter
+
+def __create_agent_knowledge_reader_and_converter(manifest):
+    reader_config = manifest['reader']
+    reader = AgentKnowledgeDocumentReader(
+        project_root=reader_config['projectRoot'],
+        agent_name=reader_config.get('agentName', 'agent'),
+        include_user_knowledge=reader_config.get('includeUserKnowledge', True),
+        include_project_knowledge=reader_config.get('includeProjectKnowledge', True),
+        fail_fast=reader_config.get('failFast', False),
+        start_from_time=__calculate_exact_update_time(manifest),
+    )
+    converter = AgentKnowledgeDocumentConverter(__create_text_splitter(manifest))
     return reader, converter

--- a/main/sources/agent_knowledge/agent_knowledge_document_converter.py
+++ b/main/sources/agent_knowledge/agent_knowledge_document_converter.py
@@ -1,0 +1,112 @@
+import logging
+import os
+
+from main.sources.base_document_converter import BaseDocumentConverter
+from main.sources.agent_knowledge.skill_frontmatter import parse_skill_markdown
+from main.splitter.base_text_splitter import BaseTextSplitter
+
+
+class AgentKnowledgeDocumentConverter(BaseDocumentConverter):
+    def __init__(self, text_splitter: BaseTextSplitter):
+        self.__text_splitter = text_splitter
+
+    def get_details(self) -> dict:
+        return {'splitter': self.__text_splitter.get_details()}
+
+    def convert(self, document) -> list[dict]:
+        skill_info = self.__parse_skill(document) if document['knowledgeType'] == 'skill' else None
+        metadata = self.__build_metadata(document, skill_info)
+        text = self.__build_document_text(document, metadata)
+        return [{
+            'id': self.__build_document_id(document, metadata),
+            'url': self.__build_url(document),
+            'metadata': metadata,
+            'text': text,
+            'chunks': self.__split_to_chunks(document, metadata, text),
+        }]
+
+    def __parse_skill(self, document):
+        parsed = parse_skill_markdown(document['content'])
+        for warning in parsed['warnings']:
+            logging.warning(f"{warning}: {document['path']}")
+        return parsed
+
+    def __build_metadata(self, document, skill_info):
+        frontmatter = skill_info['frontmatter'] if skill_info else {}
+        metadata = {
+            'knowledgeType': document['knowledgeType'],
+            'scope': document['scope'],
+            'agentName': document['agentName'],
+            'sourcePath': document['path'],
+            'rootName': document['rootName'],
+            'rootId': document['rootId'],
+            'relativePath': document['relativePath'],
+            'createdAt': document['createdTime'],
+            'lastModifiedAt': document['modifiedTime'],
+        }
+        if document['knowledgeType'] == 'skill':
+            skill_name = str(frontmatter.get('name') or self.__derive_skill_name(document)).strip()
+            skill_description = str(frontmatter.get('description') or '').strip()
+            metadata.update({'skillName': skill_name, 'skillDescription': skill_description})
+            for field in ['license', 'compatibility', 'allowed-tools']:
+                if frontmatter.get(field):
+                    metadata[self.__metadata_key(field)] = str(frontmatter[field])
+            if isinstance(frontmatter.get('metadata'), dict):
+                for key, value in frontmatter['metadata'].items():
+                    metadata[f'skillMetadata_{key}'] = str(value)
+        return metadata
+
+    def __split_to_chunks(self, document, metadata, text):
+        chunks = [{
+            'metadata': {'chunkType': 'discovery'},
+            'indexedData': self.__build_discovery_text(document, metadata),
+        }]
+        for chunk in self.__text_splitter.split_text(text):
+            chunks.append({'metadata': {'chunkType': 'content'}, 'indexedData': chunk})
+        return chunks
+
+    def __build_discovery_text(self, document, metadata):
+        if document['knowledgeType'] == 'skill':
+            return self.__convert_to_text([
+                f"Skill: {metadata.get('skillName', '')}",
+                f"Description: {metadata.get('skillDescription', '')}",
+                f"Scope: {metadata['scope']}",
+                f"Path: {metadata['sourcePath']}",
+            ], '\n')
+        return self.__convert_to_text([
+            'Memory',
+            f"Scope: {metadata['scope']}",
+            f"Path: {metadata['sourcePath']}",
+            document['relativePath'],
+        ], '\n')
+
+    def __build_document_text(self, document, metadata):
+        if document['knowledgeType'] == 'skill':
+            return self.__convert_to_text([self.__build_discovery_text(document, metadata), document['content']])
+        return self.__convert_to_text([
+            f"Memory file: {document['relativePath']}",
+            f"Scope: {document['scope']}",
+            document['content'],
+        ])
+
+    def __build_document_id(self, document, metadata):
+        if document['knowledgeType'] == 'skill':
+            skill_name = metadata.get('skillName') or self.__derive_skill_name(document)
+            return f"skill/{document['scope']}/{skill_name}/SKILL.md"
+        return f"memory/{document['scope']}/{document['rootId']}/{document['relativePath']}"
+
+    def __derive_skill_name(self, document):
+        parts = document['relativePath'].split('/')
+        if len(parts) >= 2 and parts[0] == 'skills':
+            return parts[1]
+        return os.path.basename(os.path.dirname(document['path']))
+
+    def __build_url(self, document):
+        return f"file://{document['path']}"
+
+    def __convert_to_text(self, elements, delimiter='\n\n'):
+        return delimiter.join([str(element) for element in elements if element]).strip()
+
+    def __metadata_key(self, field):
+        parts = field.split('-')
+        return parts[0] + ''.join(part.capitalize() for part in parts[1:])

--- a/main/sources/agent_knowledge/agent_knowledge_document_reader.py
+++ b/main/sources/agent_knowledge/agent_knowledge_document_reader.py
@@ -1,0 +1,143 @@
+import datetime
+import logging
+import os
+from typing import Generator
+
+from main.sources.base_document_reader import BaseDocumentReader
+
+
+class AgentKnowledgeDocumentReader(BaseDocumentReader):
+    def __init__(self,
+                 project_root: str,
+                 agent_name: str = 'agent',
+                 include_user_knowledge: bool = True,
+                 include_project_knowledge: bool = True,
+                 fail_fast: bool = False,
+                 start_from_time=None):
+        self.project_root = os.path.abspath(os.path.expanduser(project_root))
+        self.agent_name = agent_name
+        self.include_user_knowledge = include_user_knowledge
+        self.include_project_knowledge = include_project_knowledge
+        self.fail_fast = fail_fast
+        self.start_from_time = start_from_time
+        self._documents_cache = None
+
+    def read_all_documents(self) -> Generator:
+        for candidate in self.__discover_documents():
+            try:
+                with open(candidate['path'], 'r', encoding='utf-8') as f:
+                    content = f.read()
+                yield {
+                    **candidate,
+                    'createdTime': self.__read_file_creation_time(candidate['path']).isoformat(timespec='seconds'),
+                    'modifiedTime': self.__read_file_modification_time(candidate['path']).isoformat(timespec='seconds'),
+                    'content': content,
+                }
+            except Exception as e:
+                if self.fail_fast:
+                    raise RuntimeError(f"Error reading agent knowledge file {candidate['path']}") from e
+                logging.exception(f"Error reading agent knowledge file {candidate['path']}")
+
+    def get_number_of_documents(self) -> int:
+        return len(self.__discover_documents())
+
+    def get_reader_details(self) -> dict:
+        return {
+            'type': 'agentKnowledge',
+            'projectRoot': self.project_root,
+            'agentName': self.agent_name,
+            'includeUserKnowledge': self.include_user_knowledge,
+            'includeProjectKnowledge': self.include_project_knowledge,
+            'failFast': self.fail_fast,
+        }
+
+    def __discover_documents(self) -> list[dict]:
+        if self._documents_cache is not None:
+            return self._documents_cache
+        documents = []
+        for root in self.__iter_roots():
+            if not os.path.isdir(root['path']):
+                continue
+            documents.extend(self.__discover_memory_documents(root))
+            documents.extend(self.__discover_skill_documents(root))
+        self._documents_cache = documents
+        return documents
+
+    def __iter_roots(self):
+        if self.include_project_knowledge:
+            yield {'path': os.path.join(self.project_root, '.deepagents'), 'scope': 'project', 'rootName': '.deepagents', 'rootId': '.deepagents'}
+            yield {'path': os.path.join(self.project_root, '.agents'), 'scope': 'project', 'rootName': '.agents', 'rootId': '.agents'}
+        if self.include_user_knowledge:
+            home = os.path.expanduser('~')
+            yield {'path': os.path.join(home, '.deepagents', self.agent_name), 'scope': 'user', 'rootName': f'~/.deepagents/{self.agent_name}', 'rootId': f'.deepagents/{self.agent_name}'}
+            yield {'path': os.path.join(home, '.agents'), 'scope': 'user', 'rootName': '~/.agents', 'rootId': '.agents'}
+
+    def __discover_memory_documents(self, root: dict) -> list[dict]:
+        result = []
+        for current_root, dirnames, filenames in os.walk(root['path']):
+            dirnames[:] = [d for d in dirnames if self.__should_descend(d)]
+            for filename in filenames:
+                full_path = os.path.join(current_root, filename)
+                relative_path = os.path.relpath(full_path, root['path'])
+                if self.__is_skill_file(relative_path) or not self.__is_memory_file(relative_path):
+                    continue
+                if not self.__is_modified_after_watermark(full_path):
+                    continue
+                result.append(self.__build_candidate(root, full_path, relative_path, 'memory'))
+        return result
+
+    def __discover_skill_documents(self, root: dict) -> list[dict]:
+        skills_root = os.path.join(root['path'], 'skills')
+        if not os.path.isdir(skills_root):
+            return []
+        result = []
+        for current_root, dirnames, filenames in os.walk(skills_root):
+            dirnames[:] = [d for d in dirnames if not self.__is_ignored_directory(d)]
+            for filename in filenames:
+                if filename != 'SKILL.md':
+                    continue
+                full_path = os.path.join(current_root, filename)
+                if not self.__is_modified_after_watermark(full_path):
+                    continue
+                relative_path = os.path.relpath(full_path, root['path'])
+                result.append(self.__build_candidate(root, full_path, relative_path, 'skill'))
+        return result
+
+    def __build_candidate(self, root: dict, path: str, relative_path: str, knowledge_type: str) -> dict:
+        return {
+            'path': path,
+            'relativePath': relative_path.replace(os.sep, '/'),
+            'rootPath': root['path'],
+            'rootName': root['rootName'],
+            'rootId': root['rootId'],
+            'scope': root['scope'],
+            'knowledgeType': knowledge_type,
+            'agentName': self.agent_name,
+        }
+
+    def __should_descend(self, dirname: str) -> bool:
+        if dirname in {'skills', 'memories'}:
+            return dirname == 'memories'
+        return not self.__is_ignored_directory(dirname)
+
+    def __is_memory_file(self, relative_path: str) -> bool:
+        normalized = relative_path.replace(os.sep, '/')
+        return normalized == 'AGENTS.md' or normalized.endswith('.md')
+
+    def __is_skill_file(self, relative_path: str) -> bool:
+        normalized = relative_path.replace(os.sep, '/')
+        return normalized.startswith('skills/') and normalized.endswith('/SKILL.md')
+
+    def __is_ignored_directory(self, dirname: str) -> bool:
+        return dirname.startswith('.') or dirname in {'__pycache__', 'node_modules', '.pytest_cache', '.mypy_cache'}
+
+    def __is_modified_after_watermark(self, file_path: str) -> bool:
+        if self.start_from_time is None:
+            return True
+        return self.__read_file_modification_time(file_path) > self.start_from_time
+
+    def __read_file_modification_time(self, file_path: str):
+        return datetime.datetime.fromtimestamp(os.path.getmtime(file_path))
+
+    def __read_file_creation_time(self, file_path: str):
+        return datetime.datetime.fromtimestamp(os.path.getctime(file_path))

--- a/main/sources/agent_knowledge/skill_frontmatter.py
+++ b/main/sources/agent_knowledge/skill_frontmatter.py
@@ -1,0 +1,81 @@
+import re
+from typing import Any
+
+_FRONTMATTER_DELIMITER = '---'
+_REQUIRED_SKILL_FIELDS = ('name', 'description')
+
+
+def parse_skill_markdown(content: str) -> dict[str, Any]:
+    frontmatter, body = split_frontmatter(content)
+    metadata = parse_simple_yaml(frontmatter) if frontmatter is not None else {}
+    warnings = validate_skill_metadata(metadata)
+    return {'frontmatter': metadata, 'body': body, 'warnings': warnings}
+
+
+def split_frontmatter(content: str) -> tuple[str | None, str]:
+    normalized = content.replace(chr(13) + chr(10), chr(10))
+    marker = _FRONTMATTER_DELIMITER + chr(10)
+    if not normalized.startswith(marker):
+        return None, content
+    end_marker = chr(10) + _FRONTMATTER_DELIMITER + chr(10)
+    end_index = normalized.find(end_marker, len(marker))
+    if end_index == -1:
+        return None, content
+    frontmatter = normalized[len(marker):end_index]
+    body = normalized[end_index + len(end_marker):]
+    return frontmatter, body
+
+
+def parse_simple_yaml(frontmatter: str) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    current_map_key: str | None = None
+    for raw_line in frontmatter.splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith('#'):
+            continue
+        if raw_line.startswith((' ', chr(9))):
+            if current_map_key is None:
+                continue
+            nested_match = re.match(r'^\s+([^:]+):\s*(.*)$', raw_line)
+            if nested_match:
+                nested_key = nested_match.group(1).strip()
+                nested_value = _clean_scalar(nested_match.group(2).strip())
+                nested_map = result.setdefault(current_map_key, {})
+                if isinstance(nested_map, dict):
+                    nested_map[nested_key] = nested_value
+            continue
+        key, separator, value = raw_line.partition(':')
+        if not separator:
+            continue
+        current_map_key = None
+        key = key.strip()
+        value = value.strip()
+        if value == '':
+            result[key] = {}
+            current_map_key = key
+        else:
+            result[key] = _clean_scalar(value)
+    return result
+
+
+def validate_skill_metadata(metadata: dict[str, Any]) -> list[str]:
+    warnings = []
+    for field in _REQUIRED_SKILL_FIELDS:
+        if not str(metadata.get(field, '')).strip():
+            warnings.append(f'Missing required skill frontmatter field: {field}')
+    name = str(metadata.get('name', '')).strip()
+    if name and not re.fullmatch(r'[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?', name):
+        warnings.append('Skill frontmatter field name should be lowercase letters, numbers, and hyphens only')
+    if '--' in name:
+        warnings.append('Skill frontmatter field name should not contain consecutive hyphens')
+    description = str(metadata.get('description', '')).strip()
+    if len(description) > 1024:
+        warnings.append('Skill frontmatter field description should be at most 1024 characters')
+    return warnings
+
+
+def _clean_scalar(value: str) -> str:
+    if len(value) >= 2 and value.startswith(chr(34)) and value.endswith(chr(34)):
+        return value[1:-1]
+    if len(value) >= 2 and value.startswith(chr(39)) and value.endswith(chr(39)):
+        return value[1:-1]
+    return value

--- a/tests/integration/test_agent_knowledge_collection.py
+++ b/tests/integration/test_agent_knowledge_collection.py
@@ -1,0 +1,52 @@
+import os
+from datetime import datetime, timedelta
+
+from main.core.documents_collection_fetcher import DocumentCollectionFetcher
+from main.factories.create_collection_factory import create_collection_creator
+from main.factories.search_collection_factory import create_collection_searcher
+from main.factories.update_collection_factory import create_collection_updater
+from main.persisters.disk_persister import DiskPersister
+from main.sources.agent_knowledge.agent_knowledge_document_converter import AgentKnowledgeDocumentConverter
+from main.sources.agent_knowledge.agent_knowledge_document_reader import AgentKnowledgeDocumentReader
+from main.splitter.text_splitter import TextSplitter
+
+
+def _write(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding='utf-8')
+
+
+def test_agent_knowledge_collection_create_search_fetch_and_update(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    project_root = tmp_path / 'repo'
+    skill_path = project_root / '.agents' / 'skills' / 'triage' / 'SKILL.md'
+    _write(project_root / '.deepagents' / 'AGENTS.md', 'Always prefer local private indexes for project context.')
+    _write(skill_path, '---\nname: triage\ndescription: Triage bug reports and duplicates\n---\nUse this for defect intake.')
+
+    splitter = TextSplitter(chunk_size=200, chunk_overlap=20)
+    creator = create_collection_creator(
+        collection_name='agent-knowledge-test',
+        indexers=['indexer_SqlLiteBM25'],
+        document_reader=AgentKnowledgeDocumentReader(str(project_root), include_user_knowledge=False),
+        document_converter=AgentKnowledgeDocumentConverter(splitter),
+        use_cache=False,
+    )
+    creator.run()
+
+    searcher = create_collection_searcher('agent-knowledge-test')
+    skill_results = searcher.search('bug duplicates', filter='knowledgeType = "skill"', include_matched_chunks_content=True)
+    assert skill_results['results'][0]['metadata']['skillName'] == 'triage'
+
+    fetcher = DocumentCollectionFetcher('agent-knowledge-test', DiskPersister('./data/collections'))
+    fetched = fetcher.fetch('skill/project/triage/SKILL.md')
+    assert 'defect intake' in fetched['text']
+
+    _write(skill_path, '---\nname: triage\ndescription: Triage escalations\n---\nHandle sevzero incidents.')
+    future = datetime.now() + timedelta(days=1)
+    os.utime(skill_path, (future.timestamp(), future.timestamp()))
+
+    updater = create_collection_updater('agent-knowledge-test')
+    updater.run()
+
+    updated_results = create_collection_searcher('agent-knowledge-test').search('sevzero', filter='knowledgeType = "skill"', include_matched_chunks_content=True)
+    assert updated_results['results'][0]['metadata']['skillDescription'] == 'Triage escalations'

--- a/tests/sources/agent_knowledge/test_agent_knowledge_document_converter.py
+++ b/tests/sources/agent_knowledge/test_agent_knowledge_document_converter.py
@@ -1,0 +1,55 @@
+from main.sources.agent_knowledge.agent_knowledge_document_converter import AgentKnowledgeDocumentConverter
+
+
+class FakeSplitter:
+    def split_text(self, text):
+        return [text]
+
+    def get_details(self):
+        return {'chunkSize': 1000, 'chunkOverlap': 0}
+
+
+def test_converter_outputs_skill_metadata_and_discovery_chunk():
+    converter = AgentKnowledgeDocumentConverter(FakeSplitter())
+    [doc] = converter.convert({
+        'knowledgeType': 'skill',
+        'scope': 'project',
+        'agentName': 'agent',
+        'path': '/repo/.agents/skills/review/SKILL.md',
+        'rootName': '.agents',
+        'rootId': '.agents',
+        'relativePath': 'skills/review/SKILL.md',
+        'createdTime': '2026-01-01T00:00:00',
+        'modifiedTime': '2026-01-02T00:00:00',
+        'content': '---\nname: review\ndescription: Review code changes\nmetadata:\n  owner: platform\n---\n# Review\nDo it.',
+    })
+
+    assert doc['id'] == 'skill/project/review/SKILL.md'
+    assert doc['metadata']['knowledgeType'] == 'skill'
+    assert doc['metadata']['skillName'] == 'review'
+    assert doc['metadata']['skillDescription'] == 'Review code changes'
+    assert doc['metadata']['skillMetadata_owner'] == 'platform'
+    assert doc['metadata']['lastModifiedAt'] == '2026-01-02T00:00:00'
+    assert doc['chunks'][0]['metadata']['chunkType'] == 'discovery'
+    assert 'Skill: review' in doc['chunks'][0]['indexedData']
+
+
+def test_converter_outputs_memory_id_and_metadata():
+    converter = AgentKnowledgeDocumentConverter(FakeSplitter())
+    [doc] = converter.convert({
+        'knowledgeType': 'memory',
+        'scope': 'project',
+        'agentName': 'agent',
+        'path': '/repo/.deepagents/AGENTS.md',
+        'rootName': '.deepagents',
+        'rootId': '.deepagents',
+        'relativePath': 'AGENTS.md',
+        'createdTime': '2026-01-01T00:00:00',
+        'modifiedTime': '2026-01-02T00:00:00',
+        'content': 'Use snake_case APIs.',
+    })
+
+    assert doc['id'] == 'memory/project/.deepagents/AGENTS.md'
+    assert doc['metadata']['knowledgeType'] == 'memory'
+    assert doc['chunks'][0]['metadata']['chunkType'] == 'discovery'
+    assert 'Use snake_case APIs.' in doc['text']

--- a/tests/sources/agent_knowledge/test_agent_knowledge_document_reader.py
+++ b/tests/sources/agent_knowledge/test_agent_knowledge_document_reader.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timedelta
+
+from main.sources.agent_knowledge.agent_knowledge_document_reader import AgentKnowledgeDocumentReader
+
+
+def _write(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding='utf-8')
+
+
+def test_reader_discovers_project_memories_and_skills(tmp_path):
+    _write(tmp_path / '.deepagents' / 'AGENTS.md', 'Project guidance')
+    _write(tmp_path / '.deepagents' / 'memories' / 'api.md', 'API memory')
+    _write(tmp_path / '.agents' / 'skills' / 'review' / 'SKILL.md', '---\nname: review\ndescription: Review code\n---\nBody')
+    _write(tmp_path / '.agents' / '.hidden' / 'ignored.md', 'Ignore me')
+
+    reader = AgentKnowledgeDocumentReader(str(tmp_path), include_user_knowledge=False)
+    docs = list(reader.read_all_documents())
+
+    assert [doc['knowledgeType'] for doc in docs].count('memory') == 2
+    assert [doc['knowledgeType'] for doc in docs].count('skill') == 1
+    assert {doc['relativePath'] for doc in docs} == {'AGENTS.md', 'memories/api.md', 'skills/review/SKILL.md'}
+
+
+def test_reader_can_exclude_project_knowledge(tmp_path):
+    _write(tmp_path / '.deepagents' / 'AGENTS.md', 'Project guidance')
+
+    reader = AgentKnowledgeDocumentReader(str(tmp_path), include_project_knowledge=False, include_user_knowledge=False)
+
+    assert reader.get_number_of_documents() == 0
+    assert list(reader.read_all_documents()) == []
+
+
+def test_reader_respects_update_watermark(tmp_path):
+    _write(tmp_path / '.deepagents' / 'AGENTS.md', 'Project guidance')
+    future = datetime.now() + timedelta(days=1)
+
+    reader = AgentKnowledgeDocumentReader(str(tmp_path), include_user_knowledge=False, start_from_time=future)
+
+    assert reader.get_number_of_documents() == 0

--- a/tests/sources/agent_knowledge/test_skill_frontmatter.py
+++ b/tests/sources/agent_knowledge/test_skill_frontmatter.py
@@ -1,0 +1,43 @@
+from main.sources.agent_knowledge.skill_frontmatter import parse_skill_markdown
+
+
+def test_parse_valid_skill_frontmatter():
+    parsed = parse_skill_markdown('''---
+name: code-review
+description: Review code changes. Use for pull requests.
+license: MIT
+compatibility: Requires git
+allowed-tools: Bash(git:*) Read
+metadata:
+  owner: platform
+  version: "1.0"
+---
+# Instructions
+Review carefully.
+''')
+
+    assert parsed['warnings'] == []
+    assert parsed['frontmatter']['name'] == 'code-review'
+    assert parsed['frontmatter']['description'] == 'Review code changes. Use for pull requests.'
+    assert parsed['frontmatter']['metadata']['owner'] == 'platform'
+    assert parsed['frontmatter']['metadata']['version'] == '1.0'
+    assert '# Instructions' in parsed['body']
+
+
+def test_parse_missing_frontmatter_warns_for_required_fields():
+    parsed = parse_skill_markdown('# No frontmatter')
+
+    assert parsed['frontmatter'] == {}
+    assert 'Missing required skill frontmatter field: name' in parsed['warnings']
+    assert 'Missing required skill frontmatter field: description' in parsed['warnings']
+
+
+def test_parse_missing_required_field():
+    parsed = parse_skill_markdown('''---
+name: review
+---
+Body
+''')
+
+    assert parsed['frontmatter']['name'] == 'review'
+    assert parsed['warnings'] == ['Missing required skill frontmatter field: description']


### PR DESCRIPTION
## Summary
Adds MCP-ready indexing for agent memories and skills, following the Deep Agents memory/skills model while reusing the existing local collection pipeline.

## Changes
- Adds an `agentKnowledge` source for project/user `.deepagents` and `.agents` folders.
- Indexes `AGENTS.md`, memory markdown files, and `skills/*/SKILL.md`.
- Parses `SKILL.md` frontmatter for skill discovery metadata.
- Adds `agent_knowledge_collection_create_cmd_adapter.py`.
- Supports `collection_update_cmd_adapter.py` for agent knowledge collections.
- Extends unified MCP with:
  - `discover_agent_skills`
  - `search_agent_memory`
- Includes parser, reader, converter, and SQLite-only integration tests.

## Testing
- `git diff --check` passed.
- Python compile checks passed for changed files.
- Lightweight parser and reader/converter smoke checks passed.